### PR TITLE
Split FL History into Active and Orphan based on Voter Id presence

### DIFF
--- a/3PA.API.Services/PublicRecords/Consumer/Commands/ReadFileToSql/ReadFileToSqlHandler.cs
+++ b/3PA.API.Services/PublicRecords/Consumer/Commands/ReadFileToSql/ReadFileToSqlHandler.cs
@@ -29,7 +29,7 @@ namespace _3PA.API.Services.PublicRecords.Consumer.Commands
           else
           {
             var list = repo.ReadHistories(rawText);
-            updated = repo.CommitRecords<FlHistory>(list).Result;
+            updated = repo.CommitRecords<FlHistoryActive>(list).Result;
           }          
           break;
         case "NC":

--- a/3PA.Core/Models/Fl/FlHistory.cs
+++ b/3PA.Core/Models/Fl/FlHistory.cs
@@ -3,9 +3,14 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace _3PA.Core.Models.Fl
 {
-  [Table("Histories")]
   public class FlHistory
   {
+    #region Concerning EF...
+    //foreign key already present in public records entity
+    //public string VoterId { get; set; } 
+    public FlHistory() { }
+    #endregion ...EF
+
     [Key]
     public string Id { get; set; }
     public string VoterId { get; set; }
@@ -14,9 +19,6 @@ namespace _3PA.Core.Models.Fl
     public string? ElectionType { get; set; }
     public string? HistoryCode { get; set; }
 
-    #region Concerning EF...
-    public FlHistory() { }
-    #endregion ...EF
 
     public FlHistory(string row)
     {

--- a/3PA.Core/Models/Fl/FlHistoryActive.cs
+++ b/3PA.Core/Models/Fl/FlHistoryActive.cs
@@ -1,0 +1,27 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace _3PA.Core.Models.Fl
+{
+  [Table("Histories")]
+  public class FlHistoryActive: FlHistory
+  {
+    //EF Core reference navigation property
+    public FlVoter Voter { get; set; }
+
+    public FlHistoryActive(){}
+    public FlHistoryActive(string row) : base(row){}
+
+    public FlHistoryActive(FlVoter voter, FlHistory history)
+    {
+      Voter = voter;
+      base.CountyCode = history.CountyCode;
+      base.VoterId = history.VoterId;
+      base.ElectionDate = history.ElectionDate;
+      base.ElectionType = history.ElectionType;
+      base.HistoryCode = history.HistoryCode;
+      base.Id = $"{VoterId}{ElectionDate}{ElectionType}{HistoryCode}";    
+
+    }
+  }
+}

--- a/3PA.Core/Models/Fl/FlHistoryOrphan.cs
+++ b/3PA.Core/Models/Fl/FlHistoryOrphan.cs
@@ -1,0 +1,21 @@
+﻿using System.ComponentModel.DataAnnotations.Schema;
+
+namespace _3PA.Core.Models.Fl
+{
+  [Table("OrphanHistories")]
+  public class FlHistoryOrphan : FlHistory
+  {
+    public FlHistoryOrphan(){}
+    public FlHistoryOrphan(string row) : base(row){ }
+    public FlHistoryOrphan(FlHistory history)
+    {
+      base.CountyCode = history.CountyCode;
+      base.VoterId = history.VoterId;
+      base.ElectionDate = history.ElectionDate;
+      base.ElectionType = history.ElectionType;
+      base.HistoryCode = history.HistoryCode;
+      base.Id = $"{VoterId}{ElectionDate}{ElectionType}{HistoryCode}";
+
+    }
+  }
+}

--- a/3PA.Core/Models/Fl/FlVoter.cs
+++ b/3PA.Core/Models/Fl/FlVoter.cs
@@ -8,7 +8,7 @@ namespace _3PA.Core.Models.Fl
   {
     [Key]
     public string VoterId { get; set; }
-    public string CountyCode { get; set; }    
+    public string CountyCode { get; set; }
     public string? NameLast { get; set; }
     public string? NameSuffix { get; set; }
     public string? NameFirst { get; set; }
@@ -47,6 +47,8 @@ namespace _3PA.Core.Models.Fl
     public string? EmailAddress { get; set; }
     #region Concerning EF...
     public FlVoter() { }
+    //EF Core collection navigation property
+    public ICollection<FlHistoryActive> Histories {get;set;}
     #endregion ...EF
 
     public FlVoter(string row)

--- a/3PA.Data.Sql/Fl/FlDbContext.cs
+++ b/3PA.Data.Sql/Fl/FlDbContext.cs
@@ -7,14 +7,18 @@ namespace _3PA.Data.Sql.Fl
   public class FlDbContext : DbContextBase
   {
     public DbSet<FlVoter> Voters { get; set; }
-    public DbSet<FlHistory> Histories { get; set; }
+    public DbSet<FlHistoryActive> Histories { get; set; }
+    public DbSet<FlHistoryOrphan> OrphanHistories { get; set; }
     public string catalog => "Raw.Fl";
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
       optionsBuilder.UseSqlServer($"{base.basePath}{catalog}");
     }
-
-
+    protected override void OnModelCreating(ModelBuilder modelBuilder) {
+      modelBuilder.Entity<FlHistoryActive>()
+      .HasOne<FlVoter>(a => a.Voter)
+      .WithMany(v => v.Histories);
+    }
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,18 +1,33 @@
-
 # ThirdPartyAnimal
+```
+▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄/;~-..__-=
+███ ─▄─▄─/─█─█▄─██▄─▄▄▀█▄─▄▄▀██████/▄─
+██████─███─▄─██─███─▄─▄██─██─████████─
+█████▄▄███▄█▄█▄▄▄██▄█▄▄██▄▄▄▄████████
+██▄─▄▄─██▀▄─▄█▄─▄▄▀█─▄─▄─█▄─█─▄█████
+███─▄▄▄██─▀─███─▄─▄███─████▄─▄██████
+███/█████/█▄▄██▄█▄▄███▄▄███▄/███████▄▄
+█▀▄─▄█▄─▀█▄─▄█▄─██▄─▀█▀─▄██▀▄─▄█▄─▄███▄─~
+█─▀─███─█▄▀─███─███─█▄█─███─▀─███─██▀█▄▄▄─
+▄▄█▄▄█▄▄▄██▄▄█▄▄▄█▄▄▄█▄▄▄█▄▄█▄▄\▄▄▄▄█▄^─.
+```
+#### Project Summaries
+###### `3PA.Data.SQL` _SQL Data Access Layer_
+- Uses EF Core to commit publicly available voting records to local Sql.
+- Contains complete copy of available public records in three tables:
+    - `Voters` individual identification data.
+    - `Histories` of voters registered in the above table.
+    - `OrphanHistories` where the assigned voter registration number is not already recorded.  
+
+#### Present Coverage by U.S. State
+- **Florida** has been my primary focus as I add new features.
+- **North Carolina** provides a lot more history data than FL, and I intend to catch it up the FL's features, as I feel they are ready for release.
+    ###### Notes about future additions
+    - **Georgia** charges an extremely unreasonable $250 fee to citizen requesting voter registration data.  If you have an interest in sharing data you have already obtained, or crowd-sourcing funding to share this data, please contact `TheAutomaTom@gmail.com`
+    
+    
 Here are a few tips to get you started:
 
 * Fuck the system.
 
 * Take the cannoli
-
- }__-=`;\_▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
-  >(███'─▄─▄─/─█─█▄─██▄─▄▄▀█▄─▄▄▀████████▄─
-    ██████─███─▄─██─███─▄─▄██─██─████████─
-    █████▄▄███▄█▄█▄▄▄██▄█▄▄██▄▄▄▄████████
-   {██▄─▄▄─██▀▄─▄█▄─▄▄▀█─▄─▄─█▄─█─▄█████
-    ███─▄▄▄██─▀─███─▄─▄███─████▄─▄██████
-    ███/█████/█▄▄██▄█▄▄███▄▄███▄/███████▄▄
-   █▀▄─▄█▄─▀█▄─▄█▄─██▄─▀█▀─▄██▀▄─▄█▄─▄███▄─~
-   █─▀─███─█▄▀─███─███─█▄█─███─▀─███─██▀█▄▄▄─
-   ▄▄█▄▄█▄▄▄██▄▄█▄▄▄█▄▄▄█▄▄▄█▄▄█▄▄'\▄▄▄▄█▄^─`.


### PR DESCRIPTION
This makes sure everything in the active histories can be tied back to a voter's registered party.